### PR TITLE
Add missing option from labelPosition validator

### DIFF
--- a/src/components/FilterGrid.vue
+++ b/src/components/FilterGrid.vue
@@ -49,7 +49,7 @@ export default {
       required: false,
       default: 'horizontal',
       validator: function (value) {
-        return ['horizontal', 'vertical'].includes(value)
+        return ['horizontal', 'vertical', 'none'].includes(value)
       }
     },
     synchronous: {


### PR DESCRIPTION
Adding `'none'` option that mysteriously got removed from the validator for `labelPosition`