### PR TITLE
Interactive table pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@rtidatascience/harness": "^1.17.1",
     "bootstrap": "^4.3.1",
+    "bootstrap-icons": "^1.5.0",
     "file-saver": "^2.0.2",
     "jquery": "^3.4.1",
     "popper.js": "^1.15.0",

--- a/src/components/InteractiveTable.vue
+++ b/src/components/InteractiveTable.vue
@@ -90,7 +90,19 @@
         >
           <ul class="pagination harness-ui-interactivetable-pagination">
             <li
-              v-for="index in numberOfPages"
+              :class="`page-link ${pageNumber <= 1 ? 'disabled': ''}`"
+              @click="setPageNum(1)"
+              >
+                <i class="bi-chevron-double-left"></i>
+            </li>
+            <li
+            :class="`page-link ${pageNumber <= 1 ? 'disabled': ''}`"
+            @click="pageNumber != 1 ? setPageNum(pageNumber - 1) : ''"
+            >
+              <i class="bi-chevron-left"></i>
+            </li>
+            <li
+              v-for="index in paginationOptions"
               :key="index"
               :class="['page-item', 'harness-ui-interactivetable-pagination-pageitem', index === pageNumber ? ' active' : '']"
             >
@@ -100,6 +112,18 @@
               >
                 {{ index }}
               </button>
+            </li>
+            <li
+            :class="`page-link ${pageNumber <= 1 ? 'disabled': ''}`"
+            @click="pageNumber < numberOfPages.length ? setPageNum(pageNumber + 1) : ''"
+            >
+              <i class="bi-chevron-right"></i>
+            </li>
+            <li
+              :class="`page-link ${pageNumber <= 1 ? 'disabled': ''}`"
+              @click="setPageNum(numberOfPages.length)"
+              >
+                <i class="bi-chevron-double-right"></i>
             </li>
           </ul>
         </nav>
@@ -133,6 +157,11 @@ export default {
       validator: function (value) {
         return ['asc', 'desc'].includes(value)
       }
+    },
+    'numPaginationOptions': {
+      type: Number,
+      required: false,
+      default: 5
     }
   },
   data () {
@@ -310,6 +339,13 @@ export default {
         if (!this.isSearchable || !this.isSortable || !this.isPaginated) {
           this.LOAD_DATA()
         }
+      }
+    },
+    paginationOptions () {
+      if (this.pageNumber <= this.numPaginationOptions) {
+        return this.numberOfPages.slice(0, (this.numPaginationOptions))
+      } else {
+        return this.numberOfPages.slice(this.pageNumber - this.numPaginationOptions, this.pageNumber)
       }
     }
   },

--- a/src/components/inputs/HarnessUiCheckboxGroup.vue
+++ b/src/components/inputs/HarnessUiCheckboxGroup.vue
@@ -20,8 +20,8 @@
           aria-expanded="false"
           aria-label="Collapse Toggle"
         >
-          <i class="fas fa-angle-down" v-if="collapse && collapsed"></i>
-          <i class="fas fa-angle-up" v-if="collapse && !collapsed"></i>
+          <i class="bi-chevron-down" v-if="collapse && collapsed"></i>
+          <i class="bi-chevron-up" v-if="collapse && !collapsed"></i>
         </button>
       </legend>
       <div
@@ -89,8 +89,8 @@
               aria-expanded="false"
               aria-label="Collapse Toggle"
             >
-              <i class="fas fa-angle-down" v-if="collapse && collapsed"></i>
-              <i class="fas fa-angle-up" v-if="collapse && !collapsed"></i>
+              <i class="bi-chevron-down" v-if="collapse && collapsed"></i>
+              <i class="bi-chevron-up" v-if="collapse && !collapsed"></i>
             </button>
           </legend>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1989,6 +1989,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bootstrap-icons@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.5.0.tgz#2cb19da148aa9105cb3174de2963564982d3dc55"
+  integrity sha512-44feMc7DE1Ccpsas/1wioN8ewFJNquvi5FewA06wLnqct7CwMdGDVy41ieHaacogzDqLfG8nADIvMNp9e4bfbA==
+
 bootstrap@^4.3.1:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.0.tgz#97b9f29ac98f98dfa43bf7468262d84392552fd7"


### PR DESCRIPTION
This PR adds the following features:

* Adds [bootstrap icons](https://icons.getbootstrap.com/#install) as a dependency
* Refactors the checkbox group to use bootstrap icons instead of fontawesome
* Refactors pagination to have a set number of pages with first/previous next/last buttons

Dev note: will have to update docs, but in order to get the bootstrap icons working run `yarn add bootstrap-icons` in your test environment, and add `@import '~bootstrap-icons/font/bootstrap-icons.css';` to your `main.scss` file.