### PR TITLE
Typeahead search

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@rtidatascience/harness": "^1.17.1",
     "bootstrap": "^4.3.1",
     "bootstrap-icons": "^1.5.0",
+    "corejs-typeahead": "^1.3.1",
     "file-saver": "^2.0.2",
     "jquery": "^3.4.1",
     "popper.js": "^1.15.0",

--- a/src/components/inputs/HarnessUiCheckboxGroup.vue
+++ b/src/components/inputs/HarnessUiCheckboxGroup.vue
@@ -48,15 +48,7 @@
           v-for="(option, idx) in getOptionsForFilter(filter.key)"
           :key="idx"
         >
-          <input
-            class="form-check-input harness-ui-checkboxgroup-input"
-            type="checkbox"
-            :name="filter.key + option.key"
-            :id="filter.key + option.key"
-            :value="option.key"
-            v-model="boundValue"
-            :aria-labelledby="filter.key + option.key + '-label'"
-          />
+          <CheckboxPartial v-bind="{...$props, ...$attrs, collapsed, option}" />
           <label
             class="form-check-label harness-ui-checkboxgroup-label"
             :id="filter.key + option.key + '-label'"
@@ -100,7 +92,7 @@
             class="col-form-label harness-ui-checkboxgroup-collapse-label"
             data-toggle="collapse"
             :href="'#harness-ui-checkbox-collapse-' + filter.key"
-            :role="button"
+            role="button"
             @click="collapsed = !collapsed"
           >
             <span v-if=" collapse && getFilter(filter.key).length === getOptionsForFilter(filter.key).length">
@@ -119,15 +111,7 @@
               v-for="(option, idx) in getOptionsForFilter(filter.key)"
               :key="idx"
             >
-              <input
-                class="form-check-input harness-ui-checkboxgroup-input"
-                type="checkbox"
-                :name="filter.key + option.key"
-                :id="filter.key + option.key"
-                :value="option.key"
-                v-model="boundValue"
-              :aria-labelledby="filter.key + option.key + '-label'"
-              />
+              <CheckboxPartial v-bind="{...$props, ...$attrs, collapsed, option}" />
               <label
                 class="form-check-label harness-ui-checkboxgroup-label"
                 :id="filter.key + option.key + '-label'"
@@ -146,15 +130,7 @@
         v-for="(option, idx) in getOptionsForFilter(filter.key)"
         :key="idx"
       >
-        <input
-          class="form-check-input harness-ui-checkboxgroup-input"
-          type="checkbox"
-          :name="filter.key + option.key"
-          :id="filter.key + option.key"
-          :value="option.key"
-          v-model="boundValue"
-          :aria-labelledby="filter.key + option.key + '-label'"
-        />
+        <CheckboxPartial v-bind="{...$props, ...$attrs, collapsed, option}" />
         <label
           class="form-check-label harness-ui-checkboxgroup-label"
           :id="filter.key + option.key + '-label'"
@@ -170,9 +146,11 @@
 <script>
 import inputProps from '../mixins/inputProps'
 import inputFilter from '../mixins/inputFilter'
+import CheckboxPartial from './partials/CheckboxPartial'
 export default {
   name: 'harness-ui-checkboxgroup',
   mixins: [inputProps, inputFilter],
+  components: { CheckboxPartial },
   data: () => { return { collapsed: true } },
   props: {
     inline: {

--- a/src/components/inputs/HarnessUiInput.vue
+++ b/src/components/inputs/HarnessUiInput.vue
@@ -151,3 +151,37 @@ export default {
   }
 }
 </script>
+<style>
+  .tt-input {
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+
+.tt-hint {
+    color: #999;
+}
+
+.tt-menu {
+    max-width: 100%;
+    margin-top: 5px;
+    padding: 5px 0;
+    background-color: white;
+    border: 1px solid black;
+    border: 1px solid rgba(0, 0, 0, 0.5);
+    border-radius: 5px;
+    box-shadow: 0 5px 5px rgba(0,0,0,.5);
+}
+
+.tt-suggestion {
+    padding: 5px 10px;
+}
+
+.tt-suggestion.tt-cursor {
+    color: #fff;
+    background-color: #0097cf;
+
+}
+.tt-suggestion p {
+    margin: 0;
+}
+
+</style>

--- a/src/components/inputs/HarnessUiInput.vue
+++ b/src/components/inputs/HarnessUiInput.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    {{getFilter(this.filter.key)}}
     <div v-if="labelPosition == 'horizontal'" :class="(isFilterDirty(filter.key) ? 'dirty-filter-wrapper' : '')">
       <div class="row form-row">
         <div :class="'col-'+labelColumnSize + ' ' + (isFilterDirty(filter.key) ? 'dirty-filter-label-wrapper' : '')">

--- a/src/components/inputs/HarnessUiRadioGroup.vue
+++ b/src/components/inputs/HarnessUiRadioGroup.vue
@@ -11,16 +11,7 @@
         v-for="(option, idx) in getOptionsForFilter(filter.key)"
         :key="idx"
       >
-        <input
-          class="form-check-input databue-ui-radiogroup-input"
-          type="radio"
-          :name="filter.key"
-          :id="filter.key + option.key"
-          :value="option.key"
-          :disabled="option.disabled"
-          v-model="boundValue"
-          :aria-labelledby="filter.key + option.key + '-label'"
-        />
+        <RadioGroupPartial v-bind="{...$props, ...$attrs, option }" />
         <label
           class="form-check-label harness-ui-radiogroup-label"
           :id="filter.key + option.key + '-label'"
@@ -46,16 +37,7 @@
             v-for="(option, idx) in getOptionsForFilter(filter.key)"
             :key="idx"
           >
-            <input
-              class="form-check-input databue-ui-radiogroup-input"
-              type="radio"
-              :name="filter.key"
-              :id="filter.key + option.key"
-              :value="option.key"
-              :disabled="option.disabled"
-              v-model="boundValue"
-              :aria-labelledby="filter.key + option.key + '-label'"
-            />
+            <RadioGroupPartial v-bind="{...$props, ...$attrs, option }" />
             <label
               class="form-check-label harness-ui-radiogroup-label"
               :id="filter.key + option.key + '-label'"
@@ -73,8 +55,10 @@
 <script>
 import inputProps from '../mixins/inputProps'
 import inputFilter from '../mixins/inputFilter'
+import RadioGroupPartial from './partials/RadioGroupPartial'
 export default {
   name: 'harness-ui-radiogroup',
+  components: { RadioGroupPartial },
   mixins: [inputProps, inputFilter],
   props: {
     inline: {

--- a/src/components/inputs/HarnessUiSelect.vue
+++ b/src/components/inputs/HarnessUiSelect.vue
@@ -11,21 +11,7 @@
           />
         </div>
         <div :class="'col-'+(12 - labelColumnSize)">
-          <select
-            :multiple="multiple"
-            :class="'form-control harness-ui-select ' + (isFilterDirty(filter.key) ? 'dirty-filter-select' : '')"
-            v-model="boundValue"
-            :id="filter.key+'-select'"
-            :aria-labelledby="filter.key + '-label'"
-          >
-            <option
-              v-for="option in getOptionsForFilter(filter.key)"
-              :key="option.key"
-              :value="option.key"
-              :disabled="option.disabled"
-              v-html="option.label"
-            />
-          </select>
+          <SelectPartial v-bind="{...$props, ...$attrs}" />
           <small v-if="helperText" v-html="helperText" :class="'form-text harness-ui-select-helper-text harness-ui-helper-text ' + helperTextClass"></small>
         </div>
       </div>
@@ -37,39 +23,11 @@
         :id="filter.key+'-label'"
         v-html="filter.label"
       />
-      <select
-        :multiple="multiple"
-        :class="'form-control harness-ui-select ' + (isFilterDirty(filter.key) ? 'dirty-filter-select' : '')"
-        v-model="boundValue"
-        :id="filter.key+'-select'"
-        :aria-labelledby="filter.key + '-label'"
-      >
-        <option
-          v-for="option in getOptionsForFilter(filter.key)"
-          :key="option.key"
-          :value="option.key"
-          :disabled="option.disabled"
-          v-html="option.label"
-        />
-      </select>
+      <SelectPartial v-bind="{...$props, ...$attrs}" />
       <small v-if="helperText" v-html="helperText" :class="'form-text harness-ui-select-helper-text harness-ui-helper-text ' + helperTextClass"></small>
     </div>
     <div v-if="labelPosition == 'none'" :class="'form-inline ' + (isFilterDirty(filter.key) ? 'dirty-filter-wrapper' : '')">
-      <select
-        :multiple="multiple"
-        :class="'form-control harness-ui-select ' + (isFilterDirty(filter.key) ? 'dirty-filter-select' : '')"
-        v-model="boundValue"
-        :id="filter.key+'-select'"
-        :aria-label="filter.label"
-      >
-        <option
-          v-for="option in getOptionsForFilter(filter.key)"
-          :key="option.key"
-          :value="option.key"
-          :disabled="option.disabled"
-          v-html="option.label"
-        />
-      </select>
+      <SelectPartial v-bind="{...$props, ...$attrs}" />
       <small v-if="helperText" v-html="helperText" :class="'form-text harness-ui-select-helper-text harness-ui-helper-text ' + helperTextClass"></small>
     </div>
   </div>
@@ -77,9 +35,11 @@
 <script>
 import inputProps from '../mixins/inputProps'
 import inputFilter from '../mixins/inputFilter'
+import SelectPartial from './partials/SelectPartial'
 export default {
   name: 'harness-ui-select',
   mixins: [inputProps, inputFilter],
+  components: { SelectPartial },
   props: {
     multiple: {
       type: Boolean,

--- a/src/components/inputs/partials/CheckboxPartial.vue
+++ b/src/components/inputs/partials/CheckboxPartial.vue
@@ -1,0 +1,37 @@
+<template>
+  <input
+    class="form-check-input harness-ui-checkboxgroup-input"
+    type="checkbox"
+    :name="filter.key + option.key"
+    :id="filter.key + option.key"
+    :value="option.key"
+    v-model="boundValue"
+    :aria-labelledby="filter.key + option.key + '-label'"
+    />
+</template>
+<script>
+import inputProps from '../../mixins/inputProps'
+import inputFilter from '../../mixins/inputFilter'
+export default {
+  name: 'CheckboxPartial',
+  mixins: [inputProps, inputFilter],
+  props: {
+    inline: {
+      type: Boolean,
+      required: true
+    },
+    collapse: {
+      type: Boolean,
+      required: true
+    },
+    collapsed: {
+      type: Boolean,
+      required: true
+    },
+    option: {
+      type: Object,
+      required: true
+    }
+  }
+}
+</script>

--- a/src/components/inputs/partials/InputPartial.vue
+++ b/src/components/inputs/partials/InputPartial.vue
@@ -1,0 +1,27 @@
+<template>
+  <input
+    :type="type"
+    :class="`form-control harness-ui-${type}-input ${isFilterDirty(filter.key) ? 'dirty-filter-input' : ''} ${strictError ? 'typeahead-strict-error' : ''}`"
+    v-model="boundValue"
+    :id="`${filter.key}-${type}-input`"
+    :aria-labelledby="`${filter.key}-label`"
+    />
+</template>
+<script>
+import inputProps from '../../mixins/inputProps'
+import inputFilter from '../../mixins/inputFilter'
+export default {
+  name: 'InputPartial',
+  mixins: [inputProps, inputFilter],
+  props: {
+    type: {
+      required: true,
+      type: String
+    },
+    strictError: {
+      type: Boolean,
+      required: true
+    }
+  }
+}
+</script>

--- a/src/components/inputs/partials/RadioGroupPartial.vue
+++ b/src/components/inputs/partials/RadioGroupPartial.vue
@@ -1,0 +1,26 @@
+<template>
+  <input
+    class="form-check-input harness-ui-radiogroup-input"
+    type="radio"
+    :name="filter.key"
+    :id="filter.key + option.key"
+    :value="option.key"
+    :disabled="option.disabled"
+    v-model="boundValue"
+    :aria-labelledby="filter.key + option.key + '-label'"
+  />
+</template>
+<script>
+import inputProps from '../../mixins/inputProps'
+import inputFilter from '../../mixins/inputFilter'
+export default {
+  name: 'CheckboxPartial',
+  mixins: [inputProps, inputFilter],
+  props: {
+    option: {
+      type: Object,
+      required: true
+    }
+  }
+}
+</script>

--- a/src/components/inputs/partials/SelectPartial.vue
+++ b/src/components/inputs/partials/SelectPartial.vue
@@ -1,0 +1,32 @@
+<template>
+  <select
+      :multiple="multiple"
+      :class="'form-control harness-ui-select ' + (isFilterDirty(filter.key) ? 'dirty-filter-select' : '')"
+      v-model="boundValue"
+      :id="filter.key+'-select'"
+      :aria-labelledby="filter.key + '-label'"
+      >
+      <option
+          v-for="option in getOptionsForFilter(filter.key)"
+          :key="option.key"
+          :value="option.key"
+          :disabled="option.disabled"
+          v-html="option.label"
+      />
+  </select>
+</template>
+<script>
+import inputProps from '../../mixins/inputProps'
+import inputFilter from '../../mixins/inputFilter'
+export default {
+  name: 'SelectPartial',
+  mixins: [inputProps, inputFilter],
+  props: {
+    multiple: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  }
+}
+</script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2792,6 +2792,13 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+corejs-typeahead@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/corejs-typeahead/-/corejs-typeahead-1.3.1.tgz#26b9b158cba7f123556c74068bffce9356505bd3"
+  integrity sha512-fyNlBNWJNL6EQUnJyAunEzBzRcwR2cEHtZXBi2pndHPOJ/wpOf3wbS+/Oh+kYYS5sKowQcs0LFwMSl6Y2Xeqkw==
+  dependencies:
+    jquery ">=1.11"
+
 cosmiconfig@^5.0.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
@@ -6013,7 +6020,7 @@ jest@^23.6.0:
     import-local "^1.0.0"
     jest-cli "^23.6.0"
 
-jquery@^3.4.1:
+jquery@>=1.11, jquery@^3.4.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==


### PR DESCRIPTION
This pull request accomplishes the following:

## Refactors Inputs to use Partials
All of our inputs have some added bulk in that while the input itself remains the same, it's copy/pasted multiple times to accommodate different layouts (vertical/horizontal/none and collapse). The first commit in this PR refactors to use partials, in which the inputs themselves are abstracted to a separate component and embedded as needed. This should make changes easier and more foolproof (change once, not thrice) while also shrinking our code size and making these components more readable.

## Adding typeahead to text inputs
I'll add to the docs site once this is accepted, but the behavior is as follows:

* Adding `typeahead: true` to the props for `HarnessUiInput` enables typeahead search with [corejs-typeahead](https://github.com/corejavascript/typeahead.js/) using the basic bloodhound tokenized search engine
* Adding `strict: true` intercepts inputs and only persists the input value to harness if it matches one of the options provided
* Provides a styling class to inputs if `strict` is true and the content of the input does not evaluate correctly (to display to users that their input has not been accepted)

This feature uses the `key` of each option provided to the filter to generate the list of terms to search, for now. A future enhancement idea is to allow for labels as inputs and translating those labels into their respective keys for when that is needed.

## Bugfixes
* Fixes a small error in the checkbox group where `role` was listed as `:role`
* Fixed a styling class referencing `databue` that never got changed to `harness` by find-and-replace