### PR TITLE
Add new FilterAccordion component

### DIFF
--- a/src/components/FilterAccordion.vue
+++ b/src/components/FilterAccordion.vue
@@ -1,0 +1,191 @@
+<template>
+  <div class="row">
+    <div
+      class="accordion col-12"
+      id="filters-accordion"
+    >
+      <div
+        class="card"
+        v-for="(filterType, key) in filterTypes"
+        :id="filterType + '-card'"
+        :key="key"
+      >
+        <div
+          class="card-header"
+          :id="filterType + '-heading'"
+          @click="toggle"
+        >
+          <h2 class="mb-0">
+            <div class="row">
+              <div
+                class="col-6"
+                :id="filterType + '-col1'"
+              >
+                <i :class="'bi bi-ui-checks ' + (dirtyFilterString(filterType).length ? 'active' : '')" />
+                <button
+                  class="btn btn-link"
+                  :id="filterType + '-button'"
+                  type="button"
+                  data-toggle="collapse"
+                  :data-target="'#collapse-' + filterType"
+                  aria-expanded="false"
+                  :aria-controls="'collapse-' + filterType"
+                >
+                  {{ filterMapping(filterType) }}
+                </button>
+                <small v-if="dirtyFilterString(filterType).length">
+                  {{ dirtyFilterString(filterType) }}
+                </small>
+              </div>
+              <div
+                class="col-6 text-right"
+                :id="filterType + '-col2'"
+              >
+                <button
+                  class="btn btn-link text-right"
+                  :id="filterType + '-collapsebutton'"
+                  @click="toggle"
+                >
+                  <i
+                    class="bi bi-caret-down-square"
+                    :id="filterType + '-icon'"
+                    @click="toggle"
+                  />
+                </button>
+              </div>
+            </div>
+          </h2>
+        </div>
+        <div
+          :id="'collapse-' + filterType"
+          class="collapse"
+          :aria-labelledby="filterType+'-heading'"
+          data-parent="#filters-accordion"
+        >
+          <div class="card-body">
+            <FilterGrid
+              :columns="layout.columns"
+              :label-position="layout.labelPosition"
+              :spread="layout.spread"
+              :only="subsetFiltersByType(filterType)"
+              :clear-button="false"
+            />
+            <div class="row button-row harness-ui-filtergrid-row harness-ui-filtergrid-buttonrow">
+              <div class="col-md-12 text-center">
+                <button
+                  class="btn btn-primary btn-sm harness-ui-filtergrid-clearbutton"
+                  role="button"
+                  @click="clearFilterTypeFilters(filterType)"
+                >
+                  Clear Filters
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+import $ from 'jquery'
+export default {
+  name: 'FiltersAccordion',
+  props: {
+    validFilters: {
+      type: Array,
+      required: true
+    },
+    mappingFunction: {
+      type: Function,
+      required: false
+    },
+    filterLayout: {
+      type: Object,
+      required: false
+    }
+  },
+  computed: {
+    filterTypes () {
+      return Object.keys(this.filters).reduce((acc, filter) => {
+        filter = this.filters[filter]
+        if (!acc.includes(filter.props.filterType) && filter.props.filterType !== 'internal' && filter.props.filterType) {
+          acc.push(filter.props.filterType)
+        }
+        return acc
+      }, [])
+    },
+    layout () {
+      let newLayout = {}
+      if (!this.filterLayout) {
+        newLayout = this.filterTypes.reduce((acc, filterType) => {
+          acc[filterType] = {
+            columns: 4,
+            labelPosition: 'vertical',
+            spread: true
+          }
+          return acc
+        }, {})
+      }
+      return newLayout || this.filterLayout
+    }
+  },
+  methods: {
+    subsetFiltersByType (type) {
+      return Object.keys(this.filters).filter(
+        function (filter) {
+          return this.filters[filter].props.filterType === type && this.validFilters.includes(filter)
+        }.bind(this)
+      )
+    },
+    filterMapping (filterType) {
+      if (!this.mappingFunction) {
+        return `${filterType.replace('_', ' ')}s`
+      }
+      return this.mappingFunction(filterType)
+    },
+    // syncs the bootstrap collapse lifecycle with icons
+    toggle (event) {
+      event.preventDefault()
+      let filterType = event.target.id.split('-')[0]
+      $('#collapse-' + filterType).collapse('toggle')
+
+      // get icon
+      let icon = document.getElementById(filterType + '-icon')
+      // if icon is down, then we are opening this panel
+      if (icon.classList.contains('bi-caret-down-square')) {
+        // change from "down" to "up"
+        icon.classList.remove('bi-caret-down-square')
+        icon.classList.add('bi-caret-up-square')
+        // ensure that all other icons are "down"
+        this.filterTypes
+          .filter(fType => fType !== filterType)
+          .forEach(fType => {
+            let icon = document.getElementById(fType + '-icon')
+            if (icon.classList.contains('bi-caret-up-square')) {
+              icon.classList.remove('bi-caret-up-square')
+              icon.classList.add('bi-caret-down-square')
+            }
+          })
+      // we are closing the only open panel
+      } else if (icon.classList.contains('bi-caret-up-square')) {
+        let icon = document.getElementById(filterType + '-icon')
+        icon.classList.remove('bi-caret-up-square')
+        icon.classList.add('bi-caret-down-square')
+      }
+    },
+    dirtyFilterString (filterType) {
+      let hs = this.hs
+      return this.subsetFiltersByType(filterType)
+        .filter((f) => hs.isFilterDirty(f))
+        .map((f) => hs.getLabel(f))
+        .join(', ')
+    },
+    clearFilterTypeFilters (filterType) {
+      let filters = this.subsetFiltersByType(filterType)
+      this.initializeDefaults(filters)
+      this.loadData()
+    }
+  }
+}
+</script>

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -6,6 +6,7 @@ import DataTable508 from './components/DataTable508'
 import ChartWithTable from './components/ChartWithTable'
 import InteractiveTable from './components/InteractiveTable'
 import FilterPicker from './components/FilterPicker'
+import FilterAccordion from './components/FilterAccordion'
 import HarnessUiInput from './components/inputs/HarnessUiInput'
 import HarnessUiSelect from './components/inputs/HarnessUiSelect'
 import HarnessUiRadioGroup from './components/inputs/HarnessUiRadioGroup'
@@ -20,6 +21,7 @@ const components = {
   ChartWithTable,
   InteractiveTable,
   FilterPicker,
+  FilterAccordion,
   HarnessUiInput,
   HarnessUiSelect,
   HarnessUiRadioGroup,


### PR DESCRIPTION
This PR creates the new `FilterAccordion` component. 

By adding the `filterType` prop to every filter, developers can create an accordion to manage filters for a harness page. Each filter type is given its own section of the accordion to host the associate filters. 
Filter accordions take 3 props:
1. `validFilters`
  - Array of filters to be displayed in the accordion
2. `mappingFunction`
  - Function that transforms the filter type into a custom header for the associated section
  - This can be as simple as taking in a `filterType` argument and returning 
```    
`${filterType.replace('_', ' ')}s`
```
3. `filterLayout`
  - Object that specifies the layout for the internal `FilterGrid` components in the accordian
  - Formatted like so, with each key being a `filterType`:
```
{
    'Select_Type': {
        columns: 2,
        labelPosition: 'vertical',
        spread: true
    },
    'Input_Type': {
        columns: 4,
        labelPosition: 'vertical',
        spread: true
    }
}
```