### PR TITLE
adding title tags to selects

### DIFF
--- a/src/components/inputs/partials/SelectPartial.vue
+++ b/src/components/inputs/partials/SelectPartial.vue
@@ -11,6 +11,7 @@
           :key="option.key"
           :value="option.key"
           :disabled="option.disabled"
+          :title="option.label"
           v-html="option.label"
       />
   </select>


### PR DESCRIPTION
As discussed in projects, this PR adds a `title` attribute to select options, which allows a hoverover effect for when options are longer than their respective display.