### PR TITLE
Accordion fix

### DIFF
--- a/src/components/FilterAccordion.vue
+++ b/src/components/FilterAccordion.vue
@@ -64,9 +64,9 @@
         >
           <div class="card-body">
             <FilterGrid
-              :columns="layout.columns"
-              :label-position="layout.labelPosition"
-              :spread="layout.spread"
+              :columns="filterGridLayout(filterType).columns"
+              :label-position="filterGridLayout(filterType).labelPosition"
+              :spread="filterGridLayout(filterType).spread"
               :only="subsetFiltersByType(filterType)"
               :clear-button="false"
             />
@@ -113,20 +113,6 @@ export default {
         }
         return acc
       }, [])
-    },
-    layout () {
-      let newLayout = {}
-      if (!this.filterLayout) {
-        newLayout = this.filterTypes.reduce((acc, filterType) => {
-          acc[filterType] = {
-            columns: 4,
-            labelPosition: 'vertical',
-            spread: true
-          }
-          return acc
-        }, {})
-      }
-      return newLayout || this.filterLayout
     }
   },
   methods: {
@@ -186,6 +172,16 @@ export default {
       let filters = this.subsetFiltersByType(filterType)
       this.initializeDefaults(filters)
       this.loadData()
+    },
+    filterGridLayout (filterType) {
+      if (!this.filterLayout) {
+        return {
+          columns: 4,
+          labelPosition: 'vertical',
+          spread: true
+        }
+      }
+      return this.filterLayout[filterType]
     }
   }
 }

--- a/src/components/FilterAccordion.vue
+++ b/src/components/FilterAccordion.vue
@@ -26,8 +26,6 @@
                   class="btn btn-link"
                   :id="filterType + '-button'"
                   type="button"
-                  data-toggle="collapse"
-                  :data-target="'#collapse-' + filterType"
                   aria-expanded="false"
                   :aria-controls="'collapse-' + filterType"
                 >

--- a/src/components/FilterAccordion.vue
+++ b/src/components/FilterAccordion.vue
@@ -9,11 +9,13 @@
         v-for="(filterType, key) in filterTypes"
         :id="filterType + '-card'"
         :key="key"
+        @click="toggle"
+        data-toggle="collapse"
+        :data-target="'#collapse-' + filterType"
       >
         <div
           class="card-header"
           :id="filterType + '-heading'"
-          @click="toggle"
         >
           <h2 class="mb-0">
             <div class="row">
@@ -133,7 +135,6 @@ export default {
     toggle (event) {
       event.preventDefault()
       let filterType = event.target.id.split('-')[0]
-      window.$('#collapse-' + filterType).collapse('toggle')
 
       // get icon
       let icon = document.getElementById(filterType + '-icon')

--- a/src/components/FilterAccordion.vue
+++ b/src/components/FilterAccordion.vue
@@ -33,7 +33,7 @@
                 >
                   {{ filterMapping(filterType) }}
                 </button>
-                <small v-if="dirtyFilterString(filterType).length">
+                <small v-if="dirtyFilterString(filterType).length" :id="filterType + '-small'">
                   {{ dirtyFilterString(filterType) }}
                 </small>
               </div>

--- a/src/components/FilterAccordion.vue
+++ b/src/components/FilterAccordion.vue
@@ -21,7 +21,7 @@
                 class="col-6"
                 :id="filterType + '-col1'"
               >
-                <i :class="'bi bi-ui-checks ' + (dirtyFilterString(filterType).length ? 'active' : '')" />
+                <i :class="'bi bi-ui-checks ' + (dirtyFilterString(filterType).length ? 'active' : '')" :id="filterType + '-checks'" />
                 <button
                   class="btn btn-link"
                   :id="filterType + '-button'"

--- a/src/components/FilterAccordion.vue
+++ b/src/components/FilterAccordion.vue
@@ -88,7 +88,6 @@
   </div>
 </template>
 <script>
-import $ from 'jquery'
 export default {
   name: 'FiltersAccordion',
   props: {

--- a/src/components/FilterAccordion.vue
+++ b/src/components/FilterAccordion.vue
@@ -9,13 +9,13 @@
         v-for="(filterType, key) in filterTypes"
         :id="filterType + '-card'"
         :key="key"
-        @click="toggle"
-        data-toggle="collapse"
-        :data-target="'#collapse-' + filterType"
       >
         <div
           class="card-header"
           :id="filterType + '-heading'"
+          @click="toggle"
+          data-toggle="collapse"
+          :data-target="'#collapse-' + filterType"
         >
           <h2 class="mb-0">
             <div class="row">


### PR DESCRIPTION
This PR fixes a few different issues that have been plaguing the `FilterAccordion` component
- The `filterLayout` prop now actually sets the layout for each section's `FilterGrid`
- Fixed some collapsing/expanding issues
  - If `dirtyFilterString` text was present, clicking on it would log an error to the console and not expand/contract the section
  - If the checks icons was clicked, it would log an error to the console and not expand/contract the section
  - When clicking on a section header, it would expand, but each subsequent click would trigger the collapse function twice, thereby keeping the section expanded, but still alternating the up/down arrow icon